### PR TITLE
Enable Korean output from PRD and expand commands

### DIFF
--- a/scripts/modules/task-manager/expand-task.js
+++ b/scripts/modules/task-manager/expand-task.js
@@ -15,6 +15,9 @@ import { generateTextService } from '../ai-services-unified.js';
 import { getDefaultSubtasks, getDebugFlag } from '../config-manager.js';
 import generateTaskFiles from './generate-task-files.js';
 
+// Utility to detect if text contains Korean characters
+const containsKorean = (text) => /[\u3131-\uD79D]/.test(text);
+
 // --- Zod Schemas (Keep from previous step) ---
 const subtaskSchema = z
 	.object({
@@ -54,8 +57,8 @@ const subtaskWrapperSchema = z.object({
  * @param {number} subtaskCount - The target number of subtasks.
  * @returns {string} The system prompt.
  */
-function generateMainSystemPrompt(subtaskCount) {
-	return `You are an AI assistant helping with task breakdown for software development.
+function generateMainSystemPrompt(subtaskCount, isKorean = false) {
+        let prompt = `You are an AI assistant helping with task breakdown for software development.
 You need to break down a high-level task into ${subtaskCount} specific subtasks that can be implemented one by one.
 
 Subtasks should:
@@ -76,6 +79,12 @@ For each subtask, provide:
 
 
 Respond ONLY with a valid JSON object containing a single key "subtasks" whose value is an array matching the structure described. Do not include any explanatory text, markdown formatting, or code block markers.`;
+
+        if (isKorean) {
+                prompt += '\n모든 응답은 한국어로 작성하세요.';
+        }
+
+        return prompt;
 }
 
 /**
@@ -87,10 +96,11 @@ Respond ONLY with a valid JSON object containing a single key "subtasks" whose v
  * @returns {string} The user prompt.
  */
 function generateMainUserPrompt(
-	task,
-	subtaskCount,
-	additionalContext,
-	nextSubtaskId
+        task,
+        subtaskCount,
+        additionalContext,
+        nextSubtaskId,
+        isKorean = false
 ) {
 	const contextPrompt = additionalContext
 		? `\n\nAdditional context: ${additionalContext}`
@@ -110,7 +120,7 @@ function generateMainUserPrompt(
   ]
 }`;
 
-	return `Break down this task into exactly ${subtaskCount} specific subtasks:
+        let prompt = `Break down this task into exactly ${subtaskCount} specific subtasks:
 
 Task ID: ${task.id}
 Title: ${task.title}
@@ -120,6 +130,12 @@ ${contextPrompt}
 
 Return ONLY the JSON object containing the "subtasks" array, matching this structure:
 ${schemaDescription}`;
+
+        if (isKorean) {
+                prompt += '\n\n모든 응답은 한국어로 작성하세요.';
+        }
+
+        return prompt;
 }
 
 /**
@@ -131,10 +147,11 @@ ${schemaDescription}`;
  * @returns {string} The user prompt.
  */
 function generateResearchUserPrompt(
-	task,
-	subtaskCount,
-	additionalContext,
-	nextSubtaskId
+        task,
+        subtaskCount,
+        additionalContext,
+        nextSubtaskId,
+        isKorean = false
 ) {
 	const contextPrompt = additionalContext
 		? `\n\nConsider this context: ${additionalContext}`
@@ -154,7 +171,7 @@ function generateResearchUserPrompt(
   ]
 }`;
 
-	return `Analyze the following task and break it down into exactly ${subtaskCount} specific subtasks using your research capabilities. Assign sequential IDs starting from ${nextSubtaskId}.
+        let prompt = `Analyze the following task and break it down into exactly ${subtaskCount} specific subtasks using your research capabilities. Assign sequential IDs starting from ${nextSubtaskId}.
 
 Parent Task:
 ID: ${task.id}
@@ -169,6 +186,12 @@ ${schemaDescription}
 Important: For the 'dependencies' field, if a subtask has no dependencies, you MUST use an empty array, for example: "dependencies": []. Do not use null or omit the field.
 
 Do not include ANY explanatory text, markdown, or code block markers. Just the JSON object.`;
+
+        if (isKorean) {
+                prompt += '\n\n모든 응답은 한국어로 작성하세요.';
+        }
+
+        return prompt;
 }
 
 /**
@@ -441,10 +464,15 @@ async function expandTask(
 			(t) => t.id === parseInt(taskId, 10)
 		);
 		if (taskIndex === -1) throw new Error(`Task ${taskId} not found`);
-		const task = data.tasks[taskIndex];
-		logger.info(
-			`Expanding task ${taskId}: ${task.title}${useResearch ? ' with research' : ''}`
-		);
+                const task = data.tasks[taskIndex];
+                const useKorean =
+                        containsKorean(task.title) ||
+                        containsKorean(task.description) ||
+                        containsKorean(task.details || '') ||
+                        containsKorean(additionalContext);
+                logger.info(
+                        `Expanding task ${taskId}: ${task.title}${useResearch ? ' with research' : ''}`
+                );
 		// --- End Task Loading/Filtering ---
 
 		// --- Handle Force Flag: Clear existing subtasks if force=true ---
@@ -523,15 +551,21 @@ async function expandTask(
 		// Determine prompt content AND system prompt
 		const nextSubtaskId = (task.subtasks?.length || 0) + 1;
 
-		if (taskAnalysis?.expansionPrompt) {
+                if (taskAnalysis?.expansionPrompt) {
 			// Use prompt from complexity report
-			promptContent = taskAnalysis.expansionPrompt;
-			// Append additional context and reasoning
-			promptContent += `\n\n${additionalContext}`.trim();
-			promptContent += `${complexityReasoningContext}`.trim();
+                        promptContent = taskAnalysis.expansionPrompt;
+                        // Append additional context and reasoning
+                        promptContent += `\n\n${additionalContext}`.trim();
+                        promptContent += `${complexityReasoningContext}`.trim();
+                        if (useKorean) {
+                                promptContent += '\n\n모든 응답은 한국어로 작성하세요.';
+                        }
 
 			// --- Use Simplified System Prompt for Report Prompts ---
-			systemPrompt = `You are an AI assistant helping with task breakdown. Generate exactly ${finalSubtaskCount} subtasks based on the provided prompt and context. Respond ONLY with a valid JSON object containing a single key "subtasks" whose value is an array of the generated subtask objects. Each subtask object in the array must have keys: "id", "title", "description", "dependencies", "details", "status". Ensure the 'id' starts from ${nextSubtaskId} and is sequential. Ensure 'dependencies' only reference valid prior subtask IDs generated in this response (starting from ${nextSubtaskId}). Ensure 'status' is 'pending'. Do not include any other text or explanation.`;
+                        systemPrompt = `You are an AI assistant helping with task breakdown. Generate exactly ${finalSubtaskCount} subtasks based on the provided prompt and context. Respond ONLY with a valid JSON object containing a single key "subtasks" whose value is an array of the generated subtask objects. Each subtask object in the array must have keys: "id", "title", "description", "dependencies", "details", "status". Ensure the 'id' starts from ${nextSubtaskId} and is sequential. Ensure 'dependencies' only reference valid prior subtask IDs generated in this response (starting from ${nextSubtaskId}). Ensure 'status' is 'pending'. Do not include any other text or explanation.`;
+                        if (useKorean) {
+                                systemPrompt += '\n모든 응답은 한국어로 작성하세요.';
+                        }
 			logger.info(
 				`Using expansion prompt from complexity report and simplified system prompt for task ${task.id}.`
 			);
@@ -540,25 +574,30 @@ async function expandTask(
 			// Use standard prompt generation
 			const combinedAdditionalContext =
 				`${additionalContext}${complexityReasoningContext}`.trim();
-			if (useResearch) {
-				promptContent = generateResearchUserPrompt(
-					task,
-					finalSubtaskCount,
-					combinedAdditionalContext,
-					nextSubtaskId
-				);
-				// Use the specific research system prompt if needed, or a standard one
-				systemPrompt = `You are an AI assistant that responds ONLY with valid JSON objects as requested. The object should contain a 'subtasks' array.`; // Or keep generateResearchSystemPrompt if it exists
-			} else {
-				promptContent = generateMainUserPrompt(
-					task,
-					finalSubtaskCount,
-					combinedAdditionalContext,
-					nextSubtaskId
-				);
-				// Use the original detailed system prompt for standard generation
-				systemPrompt = generateMainSystemPrompt(finalSubtaskCount);
-			}
+                        if (useResearch) {
+                                promptContent = generateResearchUserPrompt(
+                                        task,
+                                        finalSubtaskCount,
+                                        combinedAdditionalContext,
+                                        nextSubtaskId,
+                                        useKorean
+                                );
+                                // Use the specific research system prompt if needed, or a standard one
+                                systemPrompt = `You are an AI assistant that responds ONLY with valid JSON objects as requested. The object should contain a 'subtasks' array.`;
+                                if (useKorean) {
+                                        systemPrompt += '\n모든 응답은 한국어로 작성하세요.';
+                                }
+                        } else {
+                                promptContent = generateMainUserPrompt(
+                                        task,
+                                        finalSubtaskCount,
+                                        combinedAdditionalContext,
+                                        nextSubtaskId,
+                                        useKorean
+                                );
+                                // Use the original detailed system prompt for standard generation
+                                systemPrompt = generateMainSystemPrompt(finalSubtaskCount, useKorean);
+                        }
 			logger.info(`Using standard prompt generation for task ${task.id}.`);
 		}
 		// --- End Complexity Report / Prompt Logic ---


### PR DESCRIPTION
## Summary
- detect Korean text in `parse-prd` and `expand-task`
- instruct AI to respond in Korean when PRD or task data is Korean

## Testing
- `npm test` *(fails: Cannot find module 'jest')*